### PR TITLE
update github actions workflows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,12 +9,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn install
@@ -27,9 +27,9 @@ jobs:
       runs-on: ubuntu-latest
       steps:
           - name: Checkout
-            uses: actions/checkout@v2
+            uses: actions/checkout@v3
           - name: Cypress run
-            uses: cypress-io/github-action@v2
+            uses: cypress-io/github-action@v4
             with:
                 build: yarn build
                 start: yarn start


### PR DESCRIPTION
update workflows with : 
- actions/checkout@v3 
- actions/setup-node@v3
- cypress-io/github-action@v4
- support for node-version 18.x